### PR TITLE
Adding tests to support future implementations

### DIFF
--- a/android/CodeTest/app/build.gradle
+++ b/android/CodeTest/app/build.gradle
@@ -12,7 +12,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "com.codetest.main.CodeTestApplicationRunner"
     }
     buildTypes {
         release {
@@ -44,4 +44,7 @@ dependencies {
     testImplementation "org.koin:koin-test:$koin_version"
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation "io.mockk:mockk-android:1.10.3"
 }

--- a/android/CodeTest/app/src/androidTest/java/com/codetest/main/CodeTestApplicationRunner.kt
+++ b/android/CodeTest/app/src/androidTest/java/com/codetest/main/CodeTestApplicationRunner.kt
@@ -1,0 +1,16 @@
+package com.codetest.main
+
+import android.app.Application
+import android.content.Context
+import android.support.test.runner.AndroidJUnitRunner
+
+class CodeTestApplicationRunner : AndroidJUnitRunner() {
+
+    override fun newApplication(
+        cl: ClassLoader?,
+        className: String?,
+        context: Context?
+    ): Application {
+        return super.newApplication(cl, CodeTestApplicationTest::class.java.name, context)
+    }
+}

--- a/android/CodeTest/app/src/androidTest/java/com/codetest/main/CodeTestApplicationTest.kt
+++ b/android/CodeTest/app/src/androidTest/java/com/codetest/main/CodeTestApplicationTest.kt
@@ -1,0 +1,12 @@
+package com.codetest.main
+
+import android.app.Application
+import org.koin.core.context.startKoin
+
+class CodeTestApplicationTest : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        startKoin {  }
+    }
+}

--- a/android/CodeTest/app/src/androidTest/java/com/codetest/main/WeatherForecastActivityTest.kt
+++ b/android/CodeTest/app/src/androidTest/java/com/codetest/main/WeatherForecastActivityTest.kt
@@ -1,0 +1,61 @@
+package com.codetest.main
+
+import android.content.Intent
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.hasChildCount
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import com.codetest.R
+import com.codetest.main.model.Location
+import com.codetest.main.model.Status
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.android.synthetic.main.activity_main.view.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.loadKoinModules
+import org.koin.dsl.module
+
+@RunWith(AndroidJUnit4::class)
+class WeatherForecastActivityTest {
+
+    @get:Rule
+    var activityRule: ActivityTestRule<WeatherForecastActivity>
+            = ActivityTestRule(WeatherForecastActivity::class.java, false, false)
+
+    @Test
+    fun shouldShowRightForecastsCount_whenSuccessResponse() {
+        //Setup
+        val locationHelperMock = mockk<LocationHelper>()
+        val locations = listOf(
+            Location("id", "City", "10", Status.BARELY_SUNNY),
+            Location("id2", "City 2", "5", Status.CLOUDY)
+        )
+
+        every { locationHelperMock.getLocations(any()) } answers {
+            firstArg<(List<Location>) -> Unit>().invoke(locations)
+        }
+
+        loadKoinModules(
+            module {
+                single<LocationHelper> {
+                    locationHelperMock
+                }
+            }
+        )
+
+        //Action
+        activityRule.launchActivity(Intent())
+
+        //Assertion
+        onView(withId(R.id.recyclerView)).check(matches(hasChildCount(2)))
+
+        //Tear down
+        confirmVerified()
+    }
+
+}


### PR DESCRIPTION
### Why it was changed?
To help to support feature improvements based on the test suite output

### How it was changed?
- Adding a test package to the project and support custom runner to help to mock dependencies.
- Adding tests dependency 'mocck'
- Adding simple tests to be improved on future.

### How it was implemented?
- Adding the package `androidTest/main`.
- Add to `build.gradle` the `mockk` dependency.
- Adding custom application `CodeTestApplicationTest` 
- Adding custom runner `CodeTestApplicationRunner` 
- Adding test `WeatherForecastActivityTest` class.
