### PR TITLE
Starting MVVM architecture for forecast location list

### DIFF
--- a/android/CodeTest/app/build.gradle
+++ b/android/CodeTest/app/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     implementation "org.koin:koin-core:$koin_version"
     implementation "org.koin:koin-core-ext:$koin_version"
     implementation "org.koin:koin-android:$koin_version"
+    implementation "org.koin:koin-android-viewmodel:$koin_version"
+    implementation "android.arch.lifecycle:viewmodel:1.1.1"
+    implementation "android.arch.lifecycle:extensions:1.1.1"
 
     testImplementation 'junit:junit:4.12'
     testImplementation "org.koin:koin-test:$koin_version"

--- a/android/CodeTest/app/src/androidTest/java/com/codetest/main/WeatherForecastActivityTest.kt
+++ b/android/CodeTest/app/src/androidTest/java/com/codetest/main/WeatherForecastActivityTest.kt
@@ -9,6 +9,7 @@ import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
 import com.codetest.R
 import com.codetest.main.features.weather_list.WeatherForecastActivity
+import com.codetest.main.features.weather_list.WeatherForecastViewModel
 import com.codetest.network.model.Location
 import com.codetest.network.model.LocationsResponse
 import com.codetest.network.model.Status
@@ -18,9 +19,11 @@ import io.mockk.every
 import io.mockk.mockk
 import io.reactivex.Observable
 import org.hamcrest.Matchers.allOf
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.koin.android.viewmodel.dsl.viewModel
 import org.koin.core.context.loadKoinModules
 import org.koin.dsl.module
 
@@ -30,6 +33,15 @@ class WeatherForecastActivityTest {
     @get:Rule
     var activityRule: ActivityTestRule<WeatherForecastActivity>
             = ActivityTestRule(WeatherForecastActivity::class.java, false, false)
+
+    @Before
+    fun setup() {
+        loadKoinModules(
+            module(override = true) {
+                viewModel { WeatherForecastViewModel(get()) }
+            }
+        )
+    }
 
     @Test
     fun shouldShowRightForecastsCount_whenSuccessResponse() {

--- a/android/CodeTest/app/src/main/java/com/codetest/CodeTestApplication.kt
+++ b/android/CodeTest/app/src/main/java/com/codetest/CodeTestApplication.kt
@@ -3,6 +3,7 @@ package com.codetest
 import android.app.Application
 import android.content.Context
 import com.codetest.di.applicationModule
+import com.codetest.main.features.weather_list.di.weatherForecastModule
 import com.codetest.network.networkModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
@@ -22,7 +23,7 @@ class CodeTestApplication : Application() {
         startKoin {
             androidLogger()
             androidContext(this@CodeTestApplication)
-            modules(applicationModule, networkModule)
+            modules(applicationModule, networkModule, weatherForecastModule)
         }
     }
 }

--- a/android/CodeTest/app/src/main/java/com/codetest/main/features/weather_list/WeatherForecastActivity.kt
+++ b/android/CodeTest/app/src/main/java/com/codetest/main/features/weather_list/WeatherForecastActivity.kt
@@ -5,83 +5,58 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView
-import android.view.ViewGroup
 import com.codetest.R
 import com.codetest.main.features.add_weather.AddWeatherLocationForecastActivity
+import com.codetest.main.features.weather_list.model.WeatherActivityState
 import com.codetest.network.model.Location
-import com.codetest.network.repository.LocationRepository
-import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.activity_main.*
-import org.koin.android.ext.android.inject
+import org.koin.android.viewmodel.ext.android.viewModel
 
 
 class WeatherForecastActivity : AppCompatActivity() {
 
-    val locationHelper: LocationRepository by inject()
-
-    private lateinit var adapter: ListAdapter
-
-    private var locations: List<Location> = arrayListOf()
+    private val weatherForecastViewModel : WeatherForecastViewModel by viewModel()
 
     private val compositeDisposable = CompositeDisposable()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(com.codetest.R.layout.activity_main)
+        setContentView(R.layout.activity_main)
 
-        adapter = ListAdapter(onItemSelected = {locationId ->
-            AlertDialog.Builder(this)
-                .setTitle(resources.getString(R.string.remote_local_title))
-                .setMessage(resources.getString(R.string.remote_local_description))
-                .setPositiveButton(resources.getString(R.string.ok)) { _, _ ->
-                    compositeDisposable.add(
-                        locationHelper
-                            .deleteLocations(locationId)
-                            .subscribeOn(Schedulers.io())
-                            .observeOn(AndroidSchedulers.mainThread())
-                            .subscribe({
-                                fetchLocations()
-                            }, {
-                                showError()
-                            })
-                    )
-                }
-                .create()
-                .show()
-        })
-
-        recyclerView.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
-        recyclerView.adapter = adapter
-        adapter.notifyDataSetChanged()
+        setObservers()
 
         btn_add_forecast_location.setOnClickListener {
             Intent(this, AddWeatherLocationForecastActivity::class.java).also {
                 startActivity(it)
             }
         }
+
+        weatherForecastViewModel.fetchAllLocations()
     }
 
-    override fun onResume() {
-        super.onResume()
-        fetchLocations()
+    private fun updateForecastLocationList(locations: List<Location>) {
+        val listAdapter = WeatherForecastAdapter(locations, onItemSelected = { locationId ->
+            showDeleteConfirmation(locationId)
+        })
+        recyclerView.apply {
+            layoutManager = LinearLayoutManager(this@WeatherForecastActivity, LinearLayoutManager.VERTICAL, false)
+            adapter = listAdapter
+        }
+        listAdapter.notifyDataSetChanged()
     }
 
-    private fun fetchLocations() {
-        compositeDisposable.add(
-            locationHelper
-                .getLocations()
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe ({ response ->
-                    locations = response.locations
-                    adapter.notifyDataSetChanged()
-                }, {
-                    showError()
-                })
-        )
+    private fun setObservers() {
+        weatherForecastViewModel.state.observe(this) {
+            when (it) {
+                is WeatherActivityState.Error -> showError()
+                is WeatherActivityState.ShowLocationForecastList -> {
+                    updateForecastLocationList(it.locations)
+                }
+                is WeatherActivityState.Loading -> {
+                }
+            }
+        }
     }
 
     private fun showError() {
@@ -93,22 +68,19 @@ class WeatherForecastActivity : AppCompatActivity() {
             .show()
     }
 
+    private fun showDeleteConfirmation(locationId: String) {
+        AlertDialog.Builder(this)
+            .setTitle(resources.getString(R.string.remote_local_title))
+            .setMessage(resources.getString(R.string.remote_local_description))
+            .setPositiveButton(resources.getString(R.string.ok)) { _, _ ->
+                weatherForecastViewModel.removeLocationById(locationId)
+            }
+            .create()
+            .show()
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         compositeDisposable.dispose()
-    }
-
-    private inner class ListAdapter(val onItemSelected: (String) -> Unit) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-        override fun getItemCount(): Int {
-            return locations.size
-        }
-
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-            return LocationViewHolder.create(parent, onItemSelected)
-        }
-
-        override fun onBindViewHolder(viewHolder: RecyclerView.ViewHolder, position: Int) {
-            (viewHolder as? LocationViewHolder)?.setup(locations[position])
-        }
     }
 }

--- a/android/CodeTest/app/src/main/java/com/codetest/main/features/weather_list/WeatherForecastAdapter.kt
+++ b/android/CodeTest/app/src/main/java/com/codetest/main/features/weather_list/WeatherForecastAdapter.kt
@@ -1,0 +1,22 @@
+package com.codetest.main.features.weather_list
+
+import android.support.v7.widget.RecyclerView
+import android.view.ViewGroup
+import com.codetest.network.model.Location
+
+class WeatherForecastAdapter(
+    val locations: List<Location>,
+    val onItemSelected: (String) -> Unit
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    override fun getItemCount(): Int {
+        return locations.size
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return LocationViewHolder.create(parent, onItemSelected)
+    }
+
+    override fun onBindViewHolder(viewHolder: RecyclerView.ViewHolder, position: Int) {
+        (viewHolder as? LocationViewHolder)?.setup(locations[position])
+    }
+}

--- a/android/CodeTest/app/src/main/java/com/codetest/main/features/weather_list/WeatherForecastViewModel.kt
+++ b/android/CodeTest/app/src/main/java/com/codetest/main/features/weather_list/WeatherForecastViewModel.kt
@@ -1,0 +1,51 @@
+package com.codetest.main.features.weather_list
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.ViewModel
+import com.codetest.main.features.weather_list.model.WeatherActivityState
+import com.codetest.network.repository.LocationRepository
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
+
+class WeatherForecastViewModel(val locationRepository: LocationRepository) : ViewModel() {
+
+    private val compositeDisposable = CompositeDisposable()
+    private val _state = MutableLiveData<WeatherActivityState>()
+
+    val state : LiveData<WeatherActivityState> = _state
+
+    fun fetchAllLocations() {
+        _state.postValue(WeatherActivityState.Loading)
+
+        compositeDisposable.add(
+            locationRepository
+                .getLocations()
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe ({ response ->
+                    _state.postValue(WeatherActivityState.ShowLocationForecastList(
+                        response.locations
+                    ))
+                }, {
+                    _state.postValue(WeatherActivityState.Error)
+                }))
+    }
+
+    fun removeLocationById(id: String) {
+        _state.postValue(WeatherActivityState.Loading)
+        compositeDisposable.add(
+            locationRepository
+                .deleteLocations(id)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    fetchAllLocations()
+                }, {
+                    _state.postValue(WeatherActivityState.Error)
+                })
+        )
+    }
+
+}

--- a/android/CodeTest/app/src/main/java/com/codetest/main/features/weather_list/di/WeatherForecastModule.kt
+++ b/android/CodeTest/app/src/main/java/com/codetest/main/features/weather_list/di/WeatherForecastModule.kt
@@ -1,0 +1,13 @@
+package com.codetest.main.features.weather_list.di
+
+import com.codetest.main.features.weather_list.WeatherForecastViewModel
+import org.koin.android.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+
+val weatherForecastModule = module {
+
+    viewModel {
+        WeatherForecastViewModel(get())
+    }
+
+}

--- a/android/CodeTest/app/src/main/java/com/codetest/main/features/weather_list/model/WeatherActivityState.kt
+++ b/android/CodeTest/app/src/main/java/com/codetest/main/features/weather_list/model/WeatherActivityState.kt
@@ -1,0 +1,11 @@
+package com.codetest.main.features.weather_list.model
+
+import com.codetest.network.model.Location
+
+sealed class WeatherActivityState {
+
+    object Loading : WeatherActivityState()
+    object Error : WeatherActivityState()
+    class ShowLocationForecastList(val locations: List<Location>) : WeatherActivityState()
+
+}


### PR DESCRIPTION
### Why it was changed?
- To help to remove logic from UI layer and also to have a more well defined architecture on the app.
- It was decided to use MVVM considering the recommendations of google to use architecture components and the perfect match with the reactive approach (considering the RX existent code)

### How it was changed?
- Adding `LiveData` and `ViewModel` dependencies.
- Creating a ViewModel for forecast location list screen.
- Creating states to represent the forecast location list screen.
- Moving codes into new folders to well organise classes and layers.
- Moving code from forecast location list screen UI layer to the new ViewModel.
- Adjusting existent tests to cover the changes.

### How it was implemented?
- Adding google architecture components to have `LiveData` and `ViewModel`.
- Adding new folders to the features (list and add new location) and the related direct dependent classes.
- Adding `WeatherForecastViewModel` to represent the list screen `ViewModel`.
- Adding `WeatherForecastModule` to represent the list screen injections necessary.
- Refactoring `WeatherForecastActivityTest` class to adjust existent tests and create new scenarios cover.